### PR TITLE
[ fix ] some inline code markup

### DIFF
--- a/src/Tutorial/DataTypes.md
+++ b/src/Tutorial/DataTypes.md
@@ -1076,7 +1076,7 @@ signature are treated as type parameters.
    --
    -- Examples:
    -- `foldList (+) 10 [1,2,7] = 20`
-   -- `foldList String.(++) "" ["Hello","World"] = "HelloWorld"
+   -- `foldList String.(++) "" ["Hello","World"] = "HelloWorld"`
    -- `foldList last Nothing (mapList Just [1,2,3]) = Just 3`
    total
    foldList : (acc -> el -> acc) -> acc -> List el -> acc

--- a/src/Tutorial/Functions1.md
+++ b/src/Tutorial/Functions1.md
@@ -384,8 +384,8 @@ types in the *Prelude* with the exception of functions.
 * `(*)`: Multiplication
 * `(-)`: Subtraction
 * `(/)`: Division
-* `(==) : True, if two values are equal
-* `(/=) : True, if two values are not equal
+* `(==)` : True, if two values are equal
+* `(/=)` : True, if two values are not equal
 * `(<=)`, `(>=)`, `(<)`, and `(>)` : Comparison operators
 * `($)`: Function application
 


### PR DESCRIPTION
Lines with odd number of `` ` `` characters should be fine now.