### PR TITLE
[ fix ] auto escaping to fromString in Prim

### DIFF
--- a/src/Tutorial/Prim.md
+++ b/src/Tutorial/Prim.md
@@ -924,10 +924,8 @@ embed string literals known at compile time without the need
 to escape them first:
 
 ```idris
-namespace Escaped
-  export
-  fromString : (s : String) -> {auto 0 prf : escape s === s} -> Escaped
-  fromString s = MkEscaped s s prf
+implementation FromString Escaped where
+  fromString s = MkEscaped (escape s) s Refl
 
 escaped : Escaped
 escaped = "Hello World!"


### PR DESCRIPTION
When I read this paragraph, I thought that `fromString` would automatically escape all literals at compile time. But it does not. I find such behavior more natural and convenient.

https://github.com/stefan-hoeck/idris2-tutorial/blob/1c89da79deaa061598e82ab56f17aa3af3e9d15c/src/Tutorial/Prim.md?plain=1#L919-L934

You [said](https://github.com/stefan-hoeck/idris2-tutorial/pull/64#issuecomment-2171751293) that the current version is good because it does not call `escape` for correct strings. However, as I understand it, it still calls `escape` when searching for proof. If I understand the tutorial correctly, `fromString` is primarily intended for overloading literals (i.e., used at compile time). In this case, both functions use `escape` during type checking.

If I'm wrong, I'd be happy to get an explanation. I'm just learning Idris :)

If this definition was specifically chosen for educational demonstration, feel free to decline the PR.