### PR TITLE
Added solution without mapMaybe for Exercise 3.4.3f (initMaybe)

### DIFF
--- a/src/Solutions/DataTypes.idr
+++ b/src/Solutions/DataTypes.idr
@@ -204,9 +204,11 @@ lastMaybe (x :: Nil) = Just x
 lastMaybe (_ :: xs)  = lastMaybe xs
 
 initMaybe : List a -> Maybe (List a)
-initMaybe Nil        = Nothing
-initMaybe (x :: Nil) = Just Nil
-initMaybe (x :: xs)  = mapMaybe (x ::) (initMaybe xs)
+initMaybe l = case l of
+  Nil => Nothing
+  x :: xs => case initMaybe xs of
+    Nothing => Just Nil
+    Just ys => Just (x :: ys)
 
 foldList : (acc -> el -> acc) -> acc -> List el -> acc
 foldList fun vacc Nil       = vacc


### PR DESCRIPTION
I'm sure this comes down to personal taste but I thought no harm in offering it for your consideration!

I think this may be a more useful solution for two reasons:

1. The current solution uses `mapMaybe` and there are two of those: one from a previous exercise and one from `Prelude.List`. I just found it a little confusing and it was already a pretty hard problem (for me), so that ambiguity didn't help. This solution doesn't use `mapMaybe` but instead just uses the basics.
2. For recursive problems involving return types of `Maybe (List a)`, the `case rec_func xs of` construct for breaking the `List` out of the `Maybe` has been a lifeline (sorry I hope that makes sense). I think another example of that would be useful. I actually only went back to do this problem for real (I just looked at the solution the first time because I couldn't solve it) because I found later problems of that kind (e.g. Exercise 5.1.3, `traverseList`) the most difficult part of the tutorial so far and was looking for examples with illustrative solutions. This solution uses that construct.

Thank you again for this excellent resource!