### PR TITLE
Added a new list exercise to 3.iv

### DIFF
--- a/src/Solutions/DataTypes.idr
+++ b/src/Solutions/DataTypes.idr
@@ -190,6 +190,10 @@ filterList f Nil       = Nil
 filterList f (x :: xs) =
   if f x then x :: filterList f xs else filterList f xs
 
+(++) : List a -> List a -> List a
+(++) Nil ys = ys
+(++) (x :: xs) ys = x :: (Solutions.DataTypes.(++) xs ys)
+
 headMaybe : List a -> Maybe a
 headMaybe Nil      = Nothing
 headMaybe (x :: _) = Just x

--- a/src/Tutorial/DataTypes.md
+++ b/src/Tutorial/DataTypes.md
@@ -1212,6 +1212,14 @@ signature are treated as type parameters.
    total
    filterList : (a -> Bool) -> List a -> List a
 
+   -- re-implement list concatenation (++) such that e.g. (++) [1, 2] [3, 4] = [1, 2, 3, 4]
+   -- note that because this function conflicts with the standard
+   -- Prelude.List.(++), if you use it then you will need to prefix it with
+   -- the name of your module, like DataTypes.(++) or Ch3.(++). alternatively
+   -- you could simply call the function something unique like myListConcat or concat'
+   total
+   (++) : List a -> List a -> List a
+
    -- return the first value of a list, if it is non-empty
    total
    headMaybe : List a -> Maybe a


### PR DESCRIPTION
At the beginning of 6.iii, in the part discussing Vect concatenation, there was a reference to list concatenation. I implemented that as an exercise (and checked it against [Prelude.List.(++)](https://github.com/idris-lang/Idris2/blob/main/libs/prelude/Prelude/Types.idr)) and thought that was interesting. It seemed to fit better in 3.iv though. I do think because there aren't a lot of recursion exercises there, having another one is nice.

I don't know if this attempt will compile? I got an `Error: Module name Solutions.DataTypes does not match file name "DataTypes.idr"`. But I don't think I should change the module name or the file name so I'm not exactly sure what to do. It doesn't compile for me (due to that error) whether I make any changes or not